### PR TITLE
Insufficient Args Fallback Pt. 2

### DIFF
--- a/src/commands/utilities/usersettings.js
+++ b/src/commands/utilities/usersettings.js
@@ -55,7 +55,7 @@ module.exports.run = async (bot, msg) => {
         if (typeof option.type == 'function'){
             const value = option.type(
                 {
-                    arg: msg.args[1],
+                    arg: msg.args[1] || '',
                     args: msg.args.slice(1)
                 }
             )


### PR DESCRIPTION
Had to redo from the last PR; small fallback for no args with `sb!us ec` command.