### PR TITLE
Add Alias "dropped"

### DIFF
--- a/src/commands/memes/generate/droppedthis.js
+++ b/src/commands/memes/generate/droppedthis.js
@@ -3,7 +3,7 @@ module.exports = {
     description: "You dropped this",
     usage: "[text]",
     category: "memes",
-    aliases: ['youdroppedthis','udroppedthis']
+    aliases: ['dropped','youdroppedthis','udroppedthis']
 }
 
 const Canvas = require('canvas');


### PR DESCRIPTION
Suggestion by Wolveric#0897 to add "dropped" alias to udroppedthis because it's shorter/faster to type out.