### PR TITLE
feat(music): songwhip command

### DIFF
--- a/src/commands/misc/songwhip.js
+++ b/src/commands/misc/songwhip.js
@@ -1,0 +1,51 @@
+module.exports = {
+    name: "songwhip",
+    description: "Lets you share music regardless of the platform",
+    category: "misc",
+    usage: `<link>`,
+    aliases: ["sw"]
+}
+
+const axios = require('axios')
+
+module.exports.run = async (bot, msg) => {
+    if (!msg.args) {
+        return bot.cmdError("I can't convert nothing...")
+    }
+
+    const url = msg.args[0]
+    if (!isValidURL(url)) {
+        return bot.cmdError("I can't convert invalid URLs...")
+    }
+
+    const data = await axios.post('https://songwhip.com/', {url: url})
+    // You can find an example JSON dump of the response here: <https://pastebin.com/HbUTE5E6>
+    const song = JSON.parse(data)
+
+    // Keep the description at a decent length...
+    const description = song.artists[0].description
+    if (description.length > 280) {
+        description.slice(0, 277)
+        description.concat("...")
+    }
+
+    const user = msg.author;
+    const embed = bot.embed()
+    .setTitle(`${song.name} by ${song.artists[0]}`)
+    .setURL(song.url)
+    .setDescription(description)
+    .setThumbnail(song.image)
+    .setAuthor('Songwhip • Listen on any platform', 'https://songwhip.com/apple-touch-icon.png')
+    .setFooter(`Requested by: ${user.tag}`, user.avatarURL())
+
+    msg.channel.send(embed)
+}
+
+function isValidURL(url) {
+    try {
+        new URL(url)
+    } catch (e) {
+        return false
+    }
+    return true
+}


### PR DESCRIPTION
My first major contribution to SpeckyBot, let me know if I missed something.
Also my first bigger-ish JS "program", so other tips and hints are highly appreciated.

**Now, why should this be merged?**
[Songwhip](https://songwhip.com) is a small platform enabling its users to share music regardless of the platform - you post a link to a song, songwip collects known links to the same song from other music platforms and composes them in a page.
This will add the functionality to issue a command in Discord to create such a page, for ease of access - it's rather tiresome to always go to the homepage.

The API is documented as follows:
```
curl -X POST -d '{"url":"url-to-song"}' https://songwhip.com
```

The following command will render [this output](https://pastebin.com/HbUTE5E6)
```
curl -X POST -d '{"url":"https://open.spotify.com/track/0tRX7FgT91zBbahH0RvJQW"}' https://songwhip.com
```

Seeing as this is quite a lot of information, I decided to only make it a small embed with the observed structure you can see in the code. Artist description, page URL, album cover and platform title should suffice.

Thanks in advance and let me know if there are any errors - I wasn't able to spot any by testing.